### PR TITLE
Wrap orphaned text

### DIFF
--- a/jquery.wysiwyg.js
+++ b/jquery.wysiwyg.js
@@ -517,6 +517,7 @@ html: '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.o
 			resizeOptions: false,
 			rmUnusedControls: false,	// https://github.com/akzhan/jwysiwyg/issues/52
 			rmUnwantedBr: true,			// http://code.google.com/p/jwysiwyg/issues/detail?id=11
+			wrapOrphanText: false,
 			tableFiller: "Lorem ipsum",
 			initialMinHeight: null,
 
@@ -1720,6 +1721,20 @@ html: '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.o
 				var content, newContent;
 
 				content = this.getContent();
+				
+				if (this.options.wrapOrphanText) {
+                    // Step 1: Wrap any unwrapped text following a starting tag where the next tag is not the closing tag for that opening tag.
+                    //         Then try saying that three times fast.
+                    content = content.replace(/(<([A-Za-z][a-zA-Z0-9]*)\b[^>]*>)([^<]+?[^\s<]+?[^<]+?)<(?!\/\2)/g, "$1<p>$3</p><");
+                    // Step 2: Wrap any unwrapped text following a closing tag.
+                    content = content.replace(/(<\/([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>)([^<]+?[^\s<]+[^<]+?)/g, "$1<p>$3</p>");
+                    // Step 3: Wrap any unwrapped text at the very start of the document.
+                    content = content.replace(/^([^<]+?[^\s<]+[^<]+?)</, "<p>$1</p><");
+                    // Step 4: Wrap any unwrapped text following self-enclosing tags.
+                    content = content.replace(/\/>([^<]+?[^\s<]+[^<]+)/g, "/><p>$1</p>");
+                    // Step 5: If the document has no tags, wrap that too.
+                    content = content.replace(/^([^<]+)$/, "<p>$1</p>");
+                }
 
 				if (this.options.rmUnwantedBr) {
 					content = content.replace(/<br\/?>$/, "");


### PR DESCRIPTION
Added an option to wrap orphaned text in paragraph elements.

This currently does not immediately reflect the change in the design editor - I welcome suggestions for superior alternatives that do provide immediate update without (for example) nuking the user's cursor position or otherwise messing with work in progress.

Take this block for example:

    Test1
    <div>
    	Test2
    	<ul>
    		<li>Test3</li>
    	</ul>
    	Test4
    </div>
    <div>
    	Test5
    </div>
    <span>Test6</span>
    <div>
    	Test7
    	<span>Test8</span>
    </div>
    Test9

In this example, I would consider the following to be "orphaned":

* Test1, 2, 4, 7, 9

So essentially, any text that is not the exclusive content of the tag that wraps it, or any text that is not wrapped in a tag at all.

This could also be up for debate: would everyone consider all of these scenarios to truly be "orphaned"?  To me in my use case it is, but I don't know if everyone would agree.  It is possible that this needs to allow for more flexible options.