### PR TITLE
Dialog drag bind and close destroy

### DIFF
--- a/src/jwysiwyg/dialog.js
+++ b/src/jwysiwyg/dialog.js
@@ -242,8 +242,9 @@
 				if (this.options.draggable) { 
 					
 					var mouseDown = false;
+					var $dialog_topbar = that._$dialog.find("div.wysiwyg-dialog-topbar");
 					
-					that._$dialog.find("div.wysiwyg-dialog-topbar").bind("mousedown", function (e) {
+					$dialog_topbar.bind("mousedown", function (e) {
 						e.preventDefault();
 						$(this).css({ "cursor": "move" });
 						var $topbar = $(this),
@@ -253,7 +254,7 @@
 						mouseDown = true;
 						$(this).css({ "cursor": "move" });
 						
-						$(document).bind("mousemove", function (e) {
+						$dialog_topbar.bind("mousemove", function (e) {
 							e.preventDefault();
 							if (mouseDown) {
 								_dialog.css({
@@ -265,7 +266,7 @@
 							e.preventDefault();
 							mouseDown = false;
 							$topbar.css({ "cursor": "auto" });
-							$(document).unbind("mousemove").unbind("mouseup");
+							$dialog_topbar.unbind("mousemove").unbind("mouseup");
 						});
 					
 					});

--- a/src/jwysiwyg/dialog.js
+++ b/src/jwysiwyg/dialog.js
@@ -157,7 +157,8 @@
 						modal: this.options.modal,
 						draggable: this.options.draggable,
 						height: dialogHeight,
-						width: dialogWidth
+						width: dialogWidth,
+						close: that.destroy
 					});
 
 					return that._$dialog;
@@ -174,7 +175,11 @@
 				};
 
 				this.destroy = function() {
-					that._$dialog.dialog("destroy");
+					try{
+						that._$dialog.dialog("destroy").remove();
+					}catch(e){
+						//console.error(e);			//Close button may cause destroy error
+					}
 					return that._$dialog;
 				};
 			});


### PR DESCRIPTION
Changes address "default" and "jqueryui" dialogs. Default had bind code that could break other plugins. Jqueryui dialog did not remove from dom when closed from top bar.